### PR TITLE
feat: Refactor fluid solver docs: add cold plasma example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     - [x] Kappa / BiKappa / product Bikappa
 - [ ] Generalized plasma dispersion function (GPDF)
 - [ ] Integration with [VelocityDistributionFunctions.jl](https://github.com/JuliaSpacePhysics/VelocityDistributionFunctions.jl) and observation / simulation data
-- [ ] Multi-fluid solver
+- [x] Multi-fluid solver
 - [ ] Faster eigenvalue solver using Krylov methods ([Arpack](https://github.com/JuliaLinearAlgebra/Arpack.jl) / [KrylovKit](https://github.com/Jutho/KrylovKit.jl), ref: [Eigen solvers](https://docs.sciml.ai/BifurcationKit/stable/eigensolver/))
 - [ ] GPU Acceleration / Parallelization / Sparse matrix optimizations
 - [ ] Reformulate as a `SciMLProblem` for use with `SciML` (ref: [LinearSolve](https://docs.sciml.ai/LinearSolve/stable/), [ApproxFun.jl](https://juliaapproximation.github.io/ApproxFun.jl/stable/generated/Eigenvalue/))

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ makedocs(;
         "Firehose instability" => "firehose_Astfalk17.md",
         "Mirror mode" => "mirror_mode.md",
         "Ion cyclotron emission" => "ice_Irvine18.md",
+        "Cold plasma (fluid vs kinetic solver)" => "cold_plasma.md",
     ],
     plugins = [bib],
 )

--- a/docs/src/cold_plasma.md
+++ b/docs/src/cold_plasma.md
@@ -1,0 +1,70 @@
+# Case: Cold plasma (kinetic vs fluid)
+
+This page demonstrates a typical cold plasma configuration (electron–proton plasma) and compares the eigenmodes computed by the kinetic solver (`solve_kinetic_dispersion`) and the multi-fluid solver (`solve_fluid_dispersion`).
+
+The input parameters correspond to the following species table:
+
+| species | n (m⁻³) | T (eV) |
+|---:|---:|---:|
+| ions (p) | 8.7e6 | 2.857e-3 |
+| electrons (e) | 8.7e6 | 2.857e-3 |
+
+We scan `k` at fixed propagation angle `θ = 60°`.
+
+```@example coldplasma
+using PlasmaBO
+using PlasmaBO: q, me, mp, c0
+
+B0 = 100e-9 # [Tesla]
+θ = deg2rad(60)
+
+n = 8.7e6
+T = 2.857e-3
+
+ion = Maxwellian(:p, n, T)
+electron = Maxwellian(:e, n, T)
+species = (ion, electron)
+# For more control over the fluid model, we can use `FluidSpecies`
+# electron_f = FluidSpecies(:e, n, T; gamma_z = 1.0, gamma_p = 1.0)
+
+wci = abs(B0 * q / mp)
+wpi = plasma_frequency(q, n, mp)
+kn = wpi / c0
+```
+
+## Dispersion Curve Scan
+
+```@repl coldplasma
+kn_scan = 0.01:2.0:100.0;
+ks = kn_scan .* kn;
+kinetic = solve_kinetic_dispersion(species, B0, ks, θ);
+fluid_ωs = solve_fluid_dispersion(species, B0, ks, θ);
+```
+
+```@example coldplasma
+using CairoMakie
+
+let
+    fig = Figure(size = (900, 360))
+    ax1 = Axis(fig[1, 1], xlabel = "k [k_n]", ylabel = "Re(ω)/ω_ci")
+    ax2 = Axis(fig[1, 2], xlabel = "k [k_n]", ylabel = "Im(ω)/ω_ci")
+
+    for (k_norm, ωs_k, ωs_f) in zip(kn_scan, kinetic.ωs, fluid_ωs.ωs)
+        xk = fill(k_norm, length(ωs_k))
+        xf = fill(k_norm, length(ωs_f))
+
+        scatter!(ax1, xk, real.(ωs_k) ./ wci; color=:transparent, strokecolor = (:blue, 0.35), strokewidth=2, marker = :circle)
+        scatter!(ax1, xf .+ 0.05, real.(ωs_f) ./ wci; color=:red, marker = :cross)
+
+        scatter!(ax2, xk, imag.(ωs_k) ./ wci; color=:transparent, strokecolor = (:blue, 0.35), strokewidth=2, marker = :circle)
+        scatter!(ax2, xf .+ 0.05, imag.(ωs_f) ./ wci; color=:red, marker = :cross)
+    end
+    fig
+end
+```
+
+Red crosses: Fluid solver results.
+
+Blue circles: Kinetic solver results.
+
+There is a slight difference at large k for the ion cyclotron wave, which is damped due to kinetic effect.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,10 +15,11 @@ Pkg.add(url="https://github.com/JuliaSpacePhysics/PlasmaBO.jl")
 
 ## Features
 
-- [x] Hermite-Hermite (HH) expansion for arbitrary/analytic distributions
-    - [x] Maxwellian / BiMaxwellian
-    - [x] Kappa / BiKappa / product Bikappa
-- [x] Integration with [`ChargedParticles.jl`](https://juliaplasma.github.io/ChargedParticles.jl/dev/)
+- Hermite-Hermite (HH) expansion for arbitrary/analytic distributions
+    - Maxwellian / BiMaxwellian
+    - Kappa / BiKappa / product Bikappa
+- Integration with [`ChargedParticles.jl`](https://juliaplasma.github.io/ChargedParticles.jl/dev/)
+- Multi-fluid solver
 
 ## Usage Examples
 
@@ -26,7 +27,7 @@ The matrix eigenvalue method ([xieEfficientFrameworkSolving2025](@citet), [xiePD
 
 This approach is more efficient to find multiple modes at once, and doesn't require initial guesses for the root finder.
 
-Check out the [ring beam instability example](ringbeam_Umeda12.md) for detailed usage instructions, also see [firehose instability example](firehose_Astfalk17.md) for using with arbitrary velocity distributions.
+Check out the [ring beam instability example](ringbeam_Umeda12.md) for detailed usage instructions, also see [firehose instability example](firehose_Astfalk17.md) for using with arbitrary velocity distributions, and [cold plasma example](cold_plasma.md) for comparing kinetic and fluid solvers.
 
 ## Notation & Assumptions
 

--- a/src/PlasmaBO.jl
+++ b/src/PlasmaBO.jl
@@ -15,7 +15,7 @@ export Maxwellian
 export BiKappa, BiKappa2
 export gen_fv2d
 export HHSolverParam
-export FluidSpecies, FluidSolverParams, solve_fluid_dispersion
+export FluidSpecies, solve_fluid_dispersion
 export BranchPoint, track_dispersion_branch, track_dispersion_branches
 export hermite_expansion
 

--- a/src/distributions/Maxwellian.jl
+++ b/src/distributions/Maxwellian.jl
@@ -5,7 +5,7 @@ struct Maxwellian{T <: Number} <: AbstractDistribution
     vdz::T         # Parallel drift velocity (c)
     vdr::T         # Perpendicular drift velocity (c)
     q::T           # Charge
-    m::T           # Mass (units of mp)
+    m::T           # Mass
 end
 
 Base.eltype(::Maxwellian{T}) where {T} = T

--- a/src/fluid_solver.jl
+++ b/src/fluid_solver.jl
@@ -6,8 +6,8 @@
 Fluid species parameters for the multi-fluid dispersion relation solver.
 
 # Fields
-- `q`: Charge in units of electron charge
-- `m`: Mass in units of proton mass
+- `q`: Charge
+- `m`: Mass
 - `n`: Number density (m⁻³)
 - `Tz`: Parallel temperature (eV)
 - `Tp`: Perpendicular temperature (eV)
@@ -15,104 +15,114 @@ Fluid species parameters for the multi-fluid dispersion relation solver.
 - `gamma_z`: Parallel polytrope exponent (default: 1.0 for isothermal)
 - `gamma_p`: Perpendicular polytrope exponent (default: 1.0 for isothermal)
 """
-struct FluidSpecies{T}
-    q::T           # Charge (units of e)
-    m::T           # Mass (units of mp)
+struct FluidSpecies{T <: Number}
     n::T           # Number density (m^-3)
     Tz::T          # Parallel temperature (eV)
     Tp::T          # Perpendicular temperature (eV)
     vdz::T         # Parallel drift velocity (c)
     gamma_z::T     # Parallel polytrope exponent
     gamma_p::T     # Perpendicular polytrope exponent
-end
-
-plasma_frequency(s::FluidSpecies) = plasma_frequency(charge(s), s.n, mass(s))
-
-"""
-    FluidSpecies(q, m, n, Tz, Tp; vdz=0.0, gamma_z=1.0, gamma_p=1.0)
-
-Create a FluidSpecies with specified parameters.
-
-# Arguments
-- `q`: Charge in units of e (-1 for electron, 1 for proton)
-- `m`: Mass in units of proton mass
-- `n`: Number density (m⁻³)
-- `Tz`: Parallel temperature (eV)
-- `Tp`: Perpendicular temperature (eV)
-- `vdz`: Parallel drift velocity in units of c (default: 0)
-- `gamma_z`: Parallel polytrope exponent (default: 1.0, isothermal)
-- `gamma_p`: Perpendicular polytrope exponent (default: 1.0, isothermal)
-
-# Fluid Closure Models
-- `gamma_z = gamma_p = 1.0`: Isothermal
-- `gamma_z = 3.0, gamma_p = 2.0`: CGL (Chew-Goldberger-Low) model
-
-See also: [`solve_fluid_dispersion`](@ref)
-"""
-function FluidSpecies(q, m, n, Tz = 0.0, Tp = 0.0; vdz = 0.0, gamma_z = 1.0, gamma_p = 1.0)
-    T = promote_type(
-        typeof(q), typeof(m), typeof(n), typeof(Tz), typeof(Tp),
-        typeof(vdz), typeof(gamma_z), typeof(gamma_p)
-    )
-    return FluidSpecies{T}(T(q), T(m), T(n), T(Tz), T(Tp), T(vdz), T(gamma_z), T(gamma_p))
+    q::T           # Charge
+    m::T           # Mass
 end
 
 """
-    FluidSolverParams{T}
-
-Parameters for the fluid dispersion relation solver.
+    FluidSpecies(n, Tz, Tp = Tz; vdz=0.0, gamma_z=1.0, gamma_p=1.0, particle=:p, ...)
 """
-struct FluidSolverParams{T} <: AbstractSolverParams
-    qs::Vector{T}       # Charges (C)
-    ms::Vector{T}       # Masses (kg)
-    ns0::Vector{T}      # Number densities (m^-3)
-    vdsz::Vector{T}     # Parallel drift velocities (m/s)
-    Psz::Vector{T}      # Parallel pressures (Pa)
-    Psp::Vector{T}      # Perpendicular pressures (Pa)
-    gamma_z::Vector{T}  # Parallel polytrope exponents
-    gamma_p::Vector{T}  # Perpendicular polytrope exponents
-    B0::T               # Magnetic field (T)
+function FluidSpecies(n, Tz = 0.0, Tp = Tz; vdz = 0.0, gamma_z = 1.0, gamma_p = 1.0, Z = nothing, A = nothing, q = nothing, m = nothing, particle = :p)
+    q, m = _charge_mass(particle, Z, A, q, m)
+    return FluidSpecies(promote(n, Tz, Tp, vdz, gamma_z, gamma_p, q, m)...)
+end
+
+FluidSpecies(p::ParticleLike, args...; kw...) = FluidSpecies(args...; kw...)
+
+plasma_frequency(s::FluidSpecies) = plasma_frequency(s.q, s.n, s.m)
+
+# Matrix dimensions: 4 variables per species (n, vx, vy, vz) + 6 fields (Ex, Ey, Ez, Bx, By, Bz)
+_fluid_size(S::Int) = 4 * S + 6
+_fluid_size(species) = _fluid_size(length(species))
+
+_gamma_z(s::FluidSpecies) = s.gamma_z
+_gamma_p(s::FluidSpecies) = s.gamma_p
+_gamma_z(s) = 1.0
+_gamma_p(s) = 1.0
+# Pressures: P = n * k_B * T, with T in Kelvin (Tz in eV → T = Tz * q / k_B)
+_Pz(s) = s.n * s.Tz * qe
+_Pp(s) = s.n * s.Tp * qe
+
+function _assemble_fluid_species!(M, s, ind, SJ, kx, kz, B0)
+    q = s.q
+    m = s.m
+    n = s.n
+    vdz = s.vdz * c0
+    Pz = _Pz(s)
+    Pp = _Pp(s)
+
+    ρ = m * n # Mass density (kg/m³)
+    wc = q * B0 / m # Cyclotron frequency
+    csz = sqrt(_gamma_z(s) * Pz / ρ)
+    csp = sqrt(_gamma_p(s) * Pp / ρ)
+
+    # k dot v_drift
+    kvd = kz * vdz
+
+    # dn ~ n & v (continuity equation)
+    M[ind + 1, ind + 1] = kvd
+    M[ind + 1, ind + 2] = kx * n
+    M[ind + 1, ind + 4] = kz * n
+
+    # dv ~ n & v (momentum equation)
+    M[ind + 2, ind + 1] = kx * csp^2 / n
+    M[ind + 4, ind + 1] = kz * csz^2 / n
+    M[ind + 2, ind + 2] = kvd
+    M[ind + 3, ind + 3] = kvd
+    M[ind + 4, ind + 4] = kvd
+    M[ind + 3, ind + 2] = -1im * wc
+    M[ind + 2, ind + 3] = 1im * wc
+
+    # dv ~ E (Lorentz force)
+    qm = q / m
+    M[ind + 2, SJ + 1] = 1im * qm
+    M[ind + 3, SJ + 2] = 1im * qm
+    M[ind + 4, SJ + 3] = 1im * qm
+
+    # dv ~ B (magnetic force and pressure anisotropy)
+    Δ = B0 == 0 ? 0.0 : (Pp - Pz) / B0 / ρ
+    M[ind + 2, SJ + 4] = kz * Δ
+    M[ind + 2, SJ + 5] = -1im * qm * vdz
+    M[ind + 4, SJ + 4] = kx * Δ
+    M[ind + 3, SJ + 4] = 1im * qm * vdz
+    M[ind + 3, SJ + 5] = kz * Δ
+
+    # dE ~ n
+    M[SJ + 3, ind + 1] = -1im * q * vdz / ε0
+    # dE ~ v
+    M[SJ + 1, ind + 2] = -1im * q * n / ε0
+    M[SJ + 2, ind + 3] = -1im * q * n / ε0
+    M[SJ + 3, ind + 4] = -1im * q * n / ε0
+    return nothing
+end
+
+function build_fluid_dispersion_matrix(species, args...; kw...)
+    NN = _fluid_size(species)
+    M = zeros(ComplexF64, NN, NN)
+    return build_fluid_dispersion_matrix!(M, species, args...; kw...)
+end
+
+# Build the fluid dispersion matrix in-place.
+function build_fluid_dispersion_matrix!(M, species, kx, kz, B0; c2 = c0^2)
+    S = length(species)
+    SJ = 4 * S
+    for i in 1:S
+        ind = (i - 1) * 4
+        _assemble_fluid_species!(M, species[i], ind, SJ, kx, kz, B0)
+    end
+    _B_E_part!(M, SJ, kx, kz; c2)
+    return M
 end
 
 """
-    create_fluid_params(species::Vector{<:FluidSpecies}, B0)
-
-Create FluidSolverParams from a list of FluidSpecies.
-
-# Arguments
-- `species`: Vector of FluidSpecies objects
-- `B0`: Magnetic field strength (Tesla)
-"""
-function create_fluid_params(species, B0)
-    T = Float64
-
-    qs = charge.(species)
-    ms = mass.(species)
-    ns0 = [s.n for s in species]
-
-    # Temperatures in Kelvin
-    Tzs = [s.Tz * q / kb for s in species]
-    Tps = [s.Tp * q / kb for s in species]
-
-    # Drift velocities
-    vdsz = [s.vdz * c0 for s in species]
-
-    # Pressures
-    Psz = @. kb * ns0 * Tzs
-    Psp = @. kb * ns0 * Tps
-
-    # Polytrope exponents
-    gamma_z = [s.gamma_z for s in species]
-    gamma_p = [s.gamma_p for s in species]
-
-    return FluidSolverParams{T}(
-        T.(qs), T.(ms), T.(ns0), T.(vdsz),
-        T.(Psz), T.(Psp), T.(gamma_z), T.(gamma_p), T(B0)
-    )
-end
-
-"""
-    solve_fluid_dispersion(params::FluidSolverParams, kx, kz)
+    solve_fluid_dispersion(species, B0, kx, kz)
 
 Solve the multi-fluid electromagnetic dispersion relation using matrix eigenvalue method.
 
@@ -123,93 +133,25 @@ The fluid model includes:
 - Momentum equation: m(∂v/∂t + v·∇v) = q(E + v×B) - ∇P/n
 - Maxwell's equations for E and B
 
-# Arguments
-- `params`: FluidSolverParams with plasma parameters
-- `kx`: Perpendicular wave vector component (m⁻¹)
-- `kz`: Parallel wave vector component (m⁻¹)
-
-# Returns
-- Vector of complex eigenfrequencies ω (rad/s)
-
-See also: [`FluidSpecies`](@ref), [`create_fluid_params`](@ref)
+See also: [`FluidSpecies`](@ref)
 """
-function solve_fluid_dispersion(params::FluidSolverParams, kx, kz)
-    (; qs, ms, ns0, vdsz, Psz, Psp, gamma_z, gamma_p, B0) = params
-    S = length(qs)
-    # Matrix dimensions: 4 variables per species (n, vx, vy, vz) + 6 fields (Ex, Ey, Ez, Bx, By, Bz)
-    SJ = 4 * S
-    NN = SJ + 6
-
-    # Build sparse matrix
-    M = zeros(ComplexF64, NN, NN)
-
-    for s in 1:S
-        ind = (s - 1) * 4
-        qⱼ = qs[s]
-        mⱼ = ms[s]
-        nⱼ = ns0[s]
-        ρⱼ = mⱼ * nⱼ # Mass densities (kg/m^3)
-        wcⱼ = qⱼ * B0 / mⱼ # Cyclotron frequencies
-        cszⱼ = sqrt(gamma_z[s] * Psz[s] / ρⱼ)
-        cspⱼ = sqrt(gamma_p[s] * Psp[s] / ρⱼ)
-
-        # k dot v_drift
-        kvdⱼ = kz * vdsz[s]  # kx*vdsx + kz*vdsz
-
-        # dn ~ n & v (continuity equation)
-        M[ind + 1, ind + 1] = kvdⱼ
-        M[ind + 1, ind + 2] = kx * nⱼ
-        M[ind + 1, ind + 4] = kz * nⱼ
-
-        # dv ~ n & v (momentum equation)
-        M[ind + 2, ind + 1] = kx * cspⱼ^2 / nⱼ
-        M[ind + 4, ind + 1] = kz * cszⱼ^2 / nⱼ
-        M[ind + 2, ind + 2] = kvdⱼ
-        M[ind + 3, ind + 3] = kvdⱼ
-        M[ind + 4, ind + 4] = kvdⱼ
-        M[ind + 3, ind + 2] = -1im * wcⱼ
-        M[ind + 2, ind + 3] = 1im * wcⱼ
-
-        # dv ~ E (Lorentz force)
-        M[ind + 2, SJ + 1] = im * qⱼ / mⱼ
-        M[ind + 3, SJ + 2] = im * qⱼ / mⱼ
-        M[ind + 4, SJ + 3] = im * qⱼ / mⱼ
-
-        # dv ~ B (magnetic force and pressure anisotropy)
-        ∆ⱼ = B0 == 0 ? 0 : (Psp[s] - Psz[s]) / B0
-        M[ind + 2, SJ + 4] = kz * ∆ⱼ / ρⱼ
-        M[ind + 2, SJ + 5] = -im * qⱼ / mⱼ * vdsz[s]
-        M[ind + 4, SJ + 4] = kx * ∆ⱼ / ρⱼ
-        M[ind + 3, SJ + 4] = 1im * qⱼ / mⱼ * vdsz[s]
-        M[ind + 3, SJ + 5] = kz * ∆ⱼ / ρⱼ
-
-        # dE ~ n
-        M[SJ + 3, ind + 1] = -im * qⱼ * vdsz[s] / ε0
-        # dE ~ v
-        M[SJ + 1, ind + 2] = -im * qⱼ * nⱼ / ε0
-        M[SJ + 2, ind + 3] = -im * qⱼ * nⱼ / ε0
-        M[SJ + 3, ind + 4] = -im * qⱼ * nⱼ / ε0
-    end
-
-    # E(B): Faraday's law contribution to E equation
-    c2 = c0 * c0
-    M[SJ + 1, SJ + 5] = c2 * kz
-    M[SJ + 2, SJ + 4] = -c2 * kz
-    M[SJ + 2, SJ + 6] = c2 * kx
-    M[SJ + 3, SJ + 5] = -c2 * kx
-
-    # B(E): Faraday's law
-    M[SJ + 4, SJ + 2] = -kz
-    M[SJ + 5, SJ + 1] = kz
-    M[SJ + 5, SJ + 3] = -kx
-    M[SJ + 6, SJ + 2] = kx
-
-    # Solve eigenvalue problem
-    return eigen(M).values
+function solve_fluid_dispersion(species, B0, kx, kz)
+    M = build_fluid_dispersion_matrix(species, kx, kz, B0)
+    return eigvals!(M)
 end
 
+function solve_fluid_dispersion!(M, species, kx, kz, B0)
+    fill!(M, zero(eltype(M)))
+    build_fluid_dispersion_matrix!(M, species, kx, kz, B0)
+    return eigvals!(M)
+end
 
-function solve_fluid_dispersion(species, B0, kx, kz)
-    params = create_fluid_params(species, B0)
-    return solve_fluid_dispersion(params, kx, kz), params
+function solve_fluid_dispersion(species, B0, ks::AbstractVector, θ)
+    NN = _fluid_size(species)
+    M = zeros(ComplexF64, NN, NN)
+    ωs = @showprogress desc = "Solving fluid dispersion..." map(ks) do k
+        kx, kz = k .* sincos(θ)
+        solve_fluid_dispersion!(M, species, kx, kz, B0)
+    end
+    return DispersionSolution(ks, ωs)
 end

--- a/src/matrix_solver.jl
+++ b/src/matrix_solver.jl
@@ -319,24 +319,26 @@ function build_dispersion_matrix!(M, params, kx, kz; N = 2, J = 8, c2 = c0^2)
         M[SNJ + 2SNJ1 + s, SNJ3 + 2] = b32
         M[SNJ + 2SNJ1 + s, SNJ3 + 3] = b33
     end
-
-
     # E(J) coupling: J_xyz = j_xyz + sum(v_snj_xyz)
     M[SNJ3 + 1, 1:SNJ1] .= -1.0
     M[SNJ3 + 2, (SNJ1 + 1):2SNJ1] .= -1.0
     M[SNJ3 + 3, (2SNJ1 + 1):3SNJ1] .= -1.0
+    _B_E_part!(M, SNJ3, kx, kz; c2)
+    return M
+end
 
+function _B_E_part!(M, idx, kx, kz; c2 = c0^2)
     # E(B) coupling: Maxwell's equations
-    M[SNJ3 + 1, SNJ3 + 5] = c2 * kz
-    M[SNJ3 + 2, SNJ3 + 4] = -c2 * kz
-    M[SNJ3 + 2, SNJ3 + 6] = c2 * kx
-    M[SNJ3 + 3, SNJ3 + 5] = -c2 * kx
+    M[idx + 1, idx + 5] = c2 * kz
+    M[idx + 2, idx + 4] = -c2 * kz
+    M[idx + 2, idx + 6] = c2 * kx
+    M[idx + 3, idx + 5] = -c2 * kx
 
     # B(E) coupling: Faraday's law
-    M[SNJ3 + 4, SNJ3 + 2] = -kz
-    M[SNJ3 + 5, SNJ3 + 1] = kz
-    M[SNJ3 + 5, SNJ3 + 3] = -kx
-    M[SNJ3 + 6, SNJ3 + 2] = kx
+    M[idx + 4, idx + 2] = -kz
+    M[idx + 5, idx + 1] = kz
+    M[idx + 5, idx + 3] = -kx
+    M[idx + 6, idx + 2] = kx
     return M
 end
 


### PR DESCRIPTION
- Add cold plasma example comparing fluid and kinetic solvers to documentation
- Mark multi-fluid solver as complete in README roadmap
- Refactor fluid solver to use FluidSpecies directly instead of intermediate params struct
- Simplify FluidSpecies constructor to accept particle symbols and support ChargedParticles interface
- Add in-place solver variants
