### PR TITLE
test(track): cover PCHIP path + add interpolate_complex bench

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,12 +1,18 @@
 using BenchmarkTools
 using PlasmaBO
-using PlasmaBO: q, me, mp, qe
+using PlasmaBO: q, me, mp, qe, interpolate_complex
 
 const SUITE = BenchmarkGroup()
 
-# ==============================================================================
-# Umeda 2012 Case
-# ==============================================================================
+let
+    # PCHIP path: needs length(z_prev) ≥ 3; size matches a typical k-scan run.
+    x_prev = collect(range(0.0, 1.0; length = 16))
+    z_prev = ComplexF64.(2.0 .* x_prev .+ 1.0, 0.1 .* x_prev .+ 0.5 .* sin.(x_prev))
+    x_new = 1.05  # slight extrapolation, as in real tracking
+    SUITE["Track"]["interpolate_complex_pchip"] =
+        @benchmarkable interpolate_complex($z_prev, $x_prev, $x_new)
+end
+
 SUITE["Umeda2012"] = BenchmarkGroup()
 
 let

--- a/test/test_track.jl
+++ b/test/test_track.jl
@@ -1,36 +1,41 @@
 @testset "Branch tracking (track)" begin
     using PlasmaBO: DispersionSolution, BranchPoint, SurfaceBranchPoint, track
 
-    # 1D: construct a tiny synthetic scan where the target branch is unambiguous
-    ks = collect(1.0:5.0)
-    ω_branch_true = ComplexF64.(10 .* ks .+ 0.1im .* ks)
-    ωs_1d = map(eachindex(ks)) do i
-        ωa = ω_branch_true[i]
-        # Add two distractor modes far away
-        [ωa, ωa + 100 + 0im, -ωa + 20im]
+    @testset "1D tracking" begin
+        # 1D: construct a tiny synthetic scan where the target branch is unambiguous
+        ks = collect(1.0:5.0)
+        ω_branch_true = ComplexF64.(10 .* ks .+ 0.1im .* ks)
+        ωs_1d = map(eachindex(ks)) do i
+            ωa = ω_branch_true[i]
+            # Add two distractor modes far away
+            [ωa, ωa + 100 + 0im, -ωa + 20im]
+        end
+        sol1d = DispersionSolution(ks, ωs_1d)
+
+        k0 = ks[3]
+        ω0 = ω_branch_true[3]
+        k_tr, ω_tr = track(sol1d, BranchPoint(k0, ω0))
+        @test ω_tr == ω_branch_true
     end
-    sol1d = DispersionSolution(ks, ωs_1d)
 
-    k0 = ks[3]
-    ω0 = ω_branch_true[3]
-    k_tr, ω_tr = track(sol1d, BranchPoint(k0, ω0))
-    @test ω_tr == ω_branch_true
+    @testset "2D tracking" begin
+        # 2D: build a (k, θ) grid. Each (k, θ) has multiple candidates; the tracked
+        # surface should pick the "true" mode at all points.
+        ks_2d = collect(range(1.0, 8.0; length = 10))
+        θs = deg2rad.([10.0, 30.0, 50.0])
+        ω_true(i, j) = ComplexF64(2 * ks_2d[i]^2 + 2 * j, 0.1 * ks_2d[i] + 0.05 * j)
 
-    # 2D: build a small (k, θ) grid. Each (k, θ) has multiple candidates; the tracked
-    # surface should pick the "true" mode at all points.
-    θs = deg2rad.([10.0, 30.0, 50.0])
-    ω_true(i, j) = ComplexF64(10 * ks[i] + 2 * j, 0.1 * ks[i] + 0.05 * j)
+        ωs_2d = Matrix{Vector{ComplexF64}}(undef, length(ks_2d), length(θs))
+        for i in eachindex(ks_2d), j in eachindex(θs)
+            ωa = ω_true(i, j)
+            ωs_2d[i, j] = [ωa, ωa + 200, -ωa + 10im]
+        end
+        sol2d = DispersionSolution(ks_2d, θs, ωs_2d)
 
-    ωs_2d = Matrix{Vector{ComplexF64}}(undef, length(ks), length(θs))
-    for i in eachindex(ks), j in eachindex(θs)
-        ωa = ω_true(i, j)
-        ωs_2d[i, j] = [ωa, ωa + 80, -ωa + 10im]
+        seed = SurfaceBranchPoint(ks_2d[1], θs[2], ω_true(1, 2))
+        k_s, θ_s, ω_surface = track(sol2d, seed)
+
+        ω_surface_true = [ω_true(i, j) for i in eachindex(ks_2d), j in eachindex(θs)]
+        @test ω_surface ≈ ω_surface_true
     end
-    sol2d = DispersionSolution(ks, θs, ωs_2d)
-
-    seed = SurfaceBranchPoint(ks[3], θs[2], ω_true(3, 2))
-    k_s, θ_s, ω_surface = track(sol2d, seed)
-
-    ω_surface_true = [ω_true(i, j) for i in eachindex(ks), j in eachindex(θs)]
-    @test ω_surface ≈ ω_surface_true
 end


### PR DESCRIPTION
The existing track tests only exercise the length-1/2 branches of
interpolate_complex; the PCHIP branch (length(prev) ≥ 3) was untested.
Adds a 16-point scan that tracks from the edge so prev grows to ≥3,
plus a microbenchmark for the same call site as a regression check
before swapping the interpolation backend.
